### PR TITLE
[YOUQ-123] Release 및 Jenkins CI 연동

### DIFF
--- a/env/dev/.terraform.lock.hcl
+++ b/env/dev/.terraform.lock.hcl
@@ -44,6 +44,25 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.10.1"
+  hashes = [
+    "h1:rssAXPIBWhumMtToGhh63w1euKOgVOi7+9LK6qZtDUQ=",
+    "zh:0717312baed39fb0a00576297241b69b419880cad8771bf72dec97ebdc96b200",
+    "zh:0e0e287b4e8429a0700143c8159764502eba0b33b1d094bf0d4ef4d93c7802cb",
+    "zh:4f74605377dab4065aaad35a2c5fa6186558c6e2e57b9058bdc8a62cf91857b9",
+    "zh:505f4af4dedb7a4f8f45b4201900b8e16216bdc2a01cc84fe13cdbf937570e7e",
+    "zh:83f37fe692513c0ce307d487248765383e00f9a84ed95f993ce0d3efdf4204d3",
+    "zh:840e5a84e1b5744f0211f611a2c6890da58016a40aafd5971f12285164d4e29b",
+    "zh:8c03d8dee292fa0367b0511cf3e95b706e034f78025f5dff0388116e1798bf47",
+    "zh:937800d1860f6b3adbb20e65f11e5fcd940b21ce8bdb48198630426244691325",
+    "zh:c1853aa5cbbdd1d46f4b169e84c3482103f0e8575a9bb044dbde908e27348c5d",
+    "zh:c9b0f640590da20931c30818b0b0587aa517d5606cb6e8052e4e4bf38f97b54d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe8bd4dd09dc7ca218959eda1ced9115408c2cdc9b4a76964bfa455f3bcadfd3",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.22.0"
   constraints = ">= 2.10.0"

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -53,6 +53,14 @@ module "vpc" {
   tags = var.tags
 }
 
+module "ecr" {
+  source = "../../modules/ecr"
+
+  repository_names = var.repository_names
+
+  tags = var.tags
+}
+
 module "eks" {
   source = "../../modules/eks"
 

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -61,6 +61,14 @@ module "ecr" {
   tags = var.tags
 }
 
+module "s3" {
+  source = "../../modules/s3"
+
+  oidc_provider_arn = module.eks.oidc_provider_arn
+
+  tags = var.tags
+}
+
 module "eks" {
   source = "../../modules/eks"
 

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -163,6 +163,14 @@ resource "helm_release" "aws-load-balancer-controller" {
 
 }
 
+module "jenkins" {
+  source = "../../modules/jenkins"
+
+  oidc_provider_arn = module.eks.oidc_provider_arn
+
+  swagger_bucket_arn = module.s3.swagger_bucket_arn
+}
+
 
 # S3 bucket for backend
 resource "aws_s3_bucket" "tfstate" {

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -27,9 +27,17 @@ variable "vpc_public_subnets" {
   type        = list(string)
 }
 
+variable "public_subnet_tags" {
+  type = map(string)
+}
+
 variable "vpc_private_subnets" {
   description = "Private subnets for the VPC"
   type        = list(string)
+}
+
+variable "private_subnet_tags" {
+  type = map(string)
 }
 
 variable "enable_nat_gateway" {

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -52,6 +52,11 @@ variable "one_nat_gateway_per_az" {
   type = bool
 }
 
+### ECR
+variable "repository_names" {
+  type = list(string)
+}
+
 ### EKS
 
 variable "cluster_name" {

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,31 @@
+data "aws_caller_identity" "current" {}
+
+module "ecr" {
+  source = "terraform-aws-modules/ecr/aws"
+
+  count = length(var.repository_names)
+
+  repository_name = var.repository_names[count.index]
+
+  repository_read_write_access_arns = [data.aws_caller_identity.current.arn]
+  repository_image_tag_mutability   = "MUTABLE"
+  repository_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1,
+        description  = "Keep last 30 images",
+        selection = {
+          tagStatus     = "tagged",
+          tagPrefixList = ["v"],
+          countType     = "imageCountMoreThan",
+          countNumber   = 30
+        },
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,7 @@
+variable "repository_names" {
+  type = list(string)
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -1,3 +1,15 @@
 output "oidc_provider_arn" {
   value = module.eks.oidc_provider_arn
 }
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  value = module.eks.cluster_certificate_authority_data
+}
+
+output "cluster_name" {
+  value = module.eks.cluster_name
+}

--- a/modules/jenkins/.terraform.lock.hcl
+++ b/modules/jenkins/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.10.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:ll2mC5mMF+Tm/+tmDQ6p6h3oAFpMSbZsA54STMZegwI=",
+    "zh:24f8b40ba25521ec809906623ce1387542f3da848952167bc960663583a7b2c7",
+    "zh:3c12afbda4e8ed44ab8315d16bbba4329ef3f18ffe3c0d5ea456dd05472fa610",
+    "zh:4da2de97535c7fb51ede8ef9b6bd45c790005aec36daac4317a6175d2ff632fd",
+    "zh:5631fd3c02c5abe5e51a73bd77ddeaaf97b2d508845ea03bc1e5955b52d94706",
+    "zh:5bdef27b4e5b2dcd0661125fcc1e70826d545903b1e19bb8d28d2a0c812468d5",
+    "zh:7b7f6b3e00ad4b7bfaa9872388f7b8014d8c9a1fe5c3f9f57865535865727633",
+    "zh:935f7a599a3f55f69052b096491262d59787625ce5d52f729080328e5088e823",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a451a24f6675f8ad643a9b218cdb54c2af75a53d6a712daff46f64b81ec61032",
+    "zh:a5bcf820baefdc9f455222878f276a7f406a1092ac7b4c0cdbd6e588bff84847",
+    "zh:c9ab7b838a75bbcacc298658c1a04d1f0ee5935a928d821afcbe08c98cca7c5f",
+    "zh:d83855b6d66aaa03b1e66e03b7d0a4d1c9f992fce06f00011edde2a6ad6d91d6",
+    "zh:f1793e9a1e3ced98ca301ef1a294f46c06f77f6eb10f4d67ffef87ea60835421",
+    "zh:f366c99ddb16d75e07a687a60c015e8e2e0cdb593dea902385629571bd604859",
+    "zh:fb3ec60ea72144f480f495634c6d3e7a7638d7061a77c228a30768c1ae0b91f6",
+  ]
+}

--- a/modules/jenkins/main.tf
+++ b/modules/jenkins/main.tf
@@ -1,0 +1,37 @@
+module "jenkins_irsa_role" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+
+  role_name = "jenkins_role"
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = var.oidc_provider_arn
+      namespace_service_accounts = ["jenkins:jenkins"]
+    }
+  }
+
+  role_policy_arns = {
+    policy             = module.iam_policy.arn
+    ecr_policy_managed = "arn:aws:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
+  }
+}
+
+module "iam_policy" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-policy"
+
+  name = "jenkins_policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Resource = "${var.swagger_bucket_arn}/*"
+      }
+    ]
+  })
+}

--- a/modules/jenkins/variables.tf
+++ b/modules/jenkins/variables.tf
@@ -1,0 +1,7 @@
+variable "oidc_provider_arn" {
+  type = string
+}
+
+variable "swagger_bucket_arn" {
+  type = string
+}

--- a/modules/s3/.terraform.lock.hcl
+++ b/modules/s3/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.10.0"
+  constraints = ">= 4.9.0"
+  hashes = [
+    "h1:ll2mC5mMF+Tm/+tmDQ6p6h3oAFpMSbZsA54STMZegwI=",
+    "zh:24f8b40ba25521ec809906623ce1387542f3da848952167bc960663583a7b2c7",
+    "zh:3c12afbda4e8ed44ab8315d16bbba4329ef3f18ffe3c0d5ea456dd05472fa610",
+    "zh:4da2de97535c7fb51ede8ef9b6bd45c790005aec36daac4317a6175d2ff632fd",
+    "zh:5631fd3c02c5abe5e51a73bd77ddeaaf97b2d508845ea03bc1e5955b52d94706",
+    "zh:5bdef27b4e5b2dcd0661125fcc1e70826d545903b1e19bb8d28d2a0c812468d5",
+    "zh:7b7f6b3e00ad4b7bfaa9872388f7b8014d8c9a1fe5c3f9f57865535865727633",
+    "zh:935f7a599a3f55f69052b096491262d59787625ce5d52f729080328e5088e823",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a451a24f6675f8ad643a9b218cdb54c2af75a53d6a712daff46f64b81ec61032",
+    "zh:a5bcf820baefdc9f455222878f276a7f406a1092ac7b4c0cdbd6e588bff84847",
+    "zh:c9ab7b838a75bbcacc298658c1a04d1f0ee5935a928d821afcbe08c98cca7c5f",
+    "zh:d83855b6d66aaa03b1e66e03b7d0a4d1c9f992fce06f00011edde2a6ad6d91d6",
+    "zh:f1793e9a1e3ced98ca301ef1a294f46c06f77f6eb10f4d67ffef87ea60835421",
+    "zh:f366c99ddb16d75e07a687a60c015e8e2e0cdb593dea902385629571bd604859",
+    "zh:fb3ec60ea72144f480f495634c6d3e7a7638d7061a77c228a30768c1ae0b91f6",
+  ]
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,0 +1,36 @@
+resource "aws_s3_bucket" "swagger" {
+  bucket = "quizit-swagger"
+}
+
+resource "aws_s3_bucket_cors_configuration" "swagger" {
+  bucket = aws_s3_bucket.swagger.id
+
+  cors_rule {
+    allowed_headers = [""]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "swagger" {
+  bucket                  = aws_s3_bucket.swagger.id
+  block_public_acls       = true
+  block_public_policy     = false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "swagger" {
+  bucket = aws_s3_bucket.swagger.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = "*",
+        Action    = "s3:GetObject",
+        Resource  = "${aws_s3_bucket.swagger.arn}/*"
+      }
+    ]
+  })
+}

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -1,0 +1,3 @@
+output "swagger_bucket_arn" {
+  value = aws_s3_bucket.swagger.arn
+}

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,0 +1,7 @@
+variable "tags" {
+  type = map(string)
+}
+
+variable "oidc_provider_arn" {
+  type = string
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -2,11 +2,13 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.1.0"
 
-  name            = var.vpc_name
-  cidr            = var.vpc_cidr
-  azs             = var.azs
-  public_subnets  = var.vpc_public_subnets
-  private_subnets = var.vpc_private_subnets
+  name                = var.vpc_name
+  cidr                = var.vpc_cidr
+  azs                 = var.azs
+  public_subnets      = var.vpc_public_subnets
+  public_subnet_tags  = var.public_subnet_tags
+  private_subnets     = var.vpc_private_subnets
+  private_subnet_tags = var.private_subnet_tags
 
   enable_nat_gateway     = var.enable_nat_gateway
   single_nat_gateway     = var.single_nat_gateway

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -18,9 +18,17 @@ variable "vpc_public_subnets" {
   type        = list(string)
 }
 
+variable "public_subnet_tags" {
+  type = map(string)
+}
+
 variable "vpc_private_subnets" {
   description = "Private subnets for the VPC"
   type        = list(string)
+}
+
+variable "private_subnet_tags" {
+  type = map(string)
 }
 
 variable "enable_nat_gateway" {


### PR DESCRIPTION
## 작업 내용

* **서비스의 이미지들을 관리할 ECR을 생성했습니다.**
* **Jenkins를 외부로 노출시키기 위해 alb-controller ingress를 배포했습니다.**
* **Swagger 서버에 사용될 S3 버킷과 정책을 생성했습니다.**

> 

* **Helm을 통해 Jenkins를 EKS내에 배포했습니다.**
* **Jenkins 내에 Gtihub Plugin을 설치해 Webhook을 연결했습니다.**
* **각 서비스별로 Job을 생성해 Webhook을 감지합니다.**
* **Jenkins Agent Pod는 Jenkins IRSA를 가져와 자격증명을 합니다.**

> 

* **보안을 위해 DinD, DooD 방식이 아닌 kaniko를 통해 이미지를 빌드합니다.**
* **보안을 위해 직접적인 AWS Credential 및 Node Role을 사용하지 않고, IRSA를 통해 Pod 범위의 권한을 설정했습니다.**
* **보안을 위해 ECR 주소나 Github Token은 Jenkins 내의 Credential과 환경변수로 관리했습니다.**

## 코멘트

* Jenkins Agent는 항상 구동되는것이 아닌 Job을 실행할때만 Pod를 생성합니다.
* 가독성을 고려해 Jenkins pipeline의 stage를 나누었습니다.
* Git Clone부터 ECR에 적재되기까지 평균 4분정도 소요됩니다.
* ECR에는 최근 30개 까지의 이미지만 적재됩니다.
* EC2와의 호환성을 고려하여 Dockerfile의 Base 이미지로 amazoncorretto를 사용했습니다.

## 관련 이슈

* **Close #7**